### PR TITLE
Addresses DEM download issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3]
+* Change "OPERA DEM" references to "Copernicus DEM for NISAR"
+* Update Copernicus DEM for NISAR endpoints for v1.2
+* Add `fetch.download_file()` exception handling and delete partial downloads
+
 ## [0.5.2]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.5.3]
-* Change "OPERA DEM" references to "Copernicus DEM for NISAR"
-* Update Copernicus DEM for NISAR endpoints for v1.2
+* Change "OPERA DEM" references to "Modified Copernicus DEM for NISAR"
+* Update Modified Copernicus DEM for NISAR endpoints for v1.2
 * Add `fetch.download_file()` exception handling and delete partial downloads
 
 ## [0.5.2]

--- a/src/multirtc/dem.py
+++ b/src/multirtc/dem.py
@@ -15,7 +15,7 @@ from multirtc.fetch import download_file
 
 
 gdal.UseExceptions()
-URL = 'https://nisar.asf.earthdatacloud.nasa.gov/STATIC/DEM/v1.1/EPSG4326'
+URL = 'https://nisar.asf.earthdatacloud.nasa.gov/NISAR/DEM/v1.2/EPSG4326'
 EGM2008_GEOID = {
     'WORLD': [
         '/vsicurl/https://asf-dem-west.s3.amazonaws.com/GEOID/us_nga_egm2008_1.tif',
@@ -133,8 +133,8 @@ def get_dem_granule_url(lat: int, lon: int) -> str:
     lon_tens = np.floor_divide(lon, 20) * 20
     lon_cardinal = 'W' if lon_tens < 0 else 'E'
 
-    prefix = f'{lat_cardinal}{np.abs(lat_tens):02d}_{lon_cardinal}{np.abs(lon_tens):03d}'
-    filename = f'DEM_{lat_cardinal}{np.abs(lat):02d}_00_{lon_cardinal}{np.abs(lon):03d}_00.tif'
+    prefix = f'{lat_cardinal}{np.abs(lat_tens):02d}/{lat_cardinal}{np.abs(lat_tens):02d}_{lon_cardinal}{np.abs(lon_tens):03d}'
+    filename = f'DEM_{lat_cardinal}{np.abs(lat):02d}_00_{lon_cardinal}{np.abs(lon):03d}_00_C01.tif'
     file_url = f'{URL}/{prefix}/{filename}'
     return file_url
 

--- a/src/multirtc/dem.py
+++ b/src/multirtc/dem.py
@@ -118,7 +118,7 @@ def check_antimeridean(poly: Polygon) -> list[Polygon]:
 
 
 def get_dem_granule_url(lat: int, lon: int) -> str:
-    """Generate the URL for the Copernicus DEM for NISAR granule based on latitude and longitude.
+    """Generate the URL for the Modified Copernicus DEM for NISAR granule based on latitude and longitude.
 
     Args:
         lat: Latitude in degrees.
@@ -156,7 +156,7 @@ def get_latlon_pairs(polygon: Polygon) -> list[tuple[float, float]]:
 
 def download_opera_dem_for_footprint(output_path: Path, footprint: Polygon, buffer: float = 0.2) -> None:
     """
-    Download the Copernicus DEM for NISAR for a given footprint and save it to the specified output path.
+    Download the Modified Copernicus DEM for NISAR for a given footprint and save it to the specified output path.
 
     Args:
         output_path: Path where the DEM will be saved.

--- a/src/multirtc/dem.py
+++ b/src/multirtc/dem.py
@@ -118,7 +118,7 @@ def check_antimeridean(poly: Polygon) -> list[Polygon]:
 
 
 def get_dem_granule_url(lat: int, lon: int) -> str:
-    """Generate the URL for the OPERA DEM granule based on latitude and longitude.
+    """Generate the URL for the Copernicus DEM for NISAR granule based on latitude and longitude.
 
     Args:
         lat: Latitude in degrees.
@@ -134,7 +134,7 @@ def get_dem_granule_url(lat: int, lon: int) -> str:
     lon_cardinal = 'W' if lon_tens < 0 else 'E'
 
     prefix = f'{lat_cardinal}{np.abs(lat_tens):02d}/{lat_cardinal}{np.abs(lat_tens):02d}_{lon_cardinal}{np.abs(lon_tens):03d}'
-    filename = f'DEM_{lat_cardinal}{np.abs(lat):02d}_00_{lon_cardinal}{np.abs(lon):03d}_00_C01.tif'
+    filename = f'DEM{lat_cardinal}{np.abs(lat):02d}_00_{lon_cardinal}{np.abs(lon):03d}_00_C01.tif'
     file_url = f'{URL}/{prefix}/{filename}'
     return file_url
 
@@ -156,7 +156,7 @@ def get_latlon_pairs(polygon: Polygon) -> list[tuple[float, float]]:
 
 def download_opera_dem_for_footprint(output_path: Path, footprint: Polygon, buffer: float = 0.2) -> None:
     """
-    Download the OPERA DEM for a given footprint and save it to the specified output path.
+    Download the Copernicus DEM for NISAR for a given footprint and save it to the specified output path.
 
     Args:
         output_path: Path where the DEM will be saved.

--- a/src/multirtc/fetch.py
+++ b/src/multirtc/fetch.py
@@ -63,6 +63,7 @@ def download_file(
     session.mount('https://', HTTPAdapter(max_retries=retry_strategy))
     session.mount('http://', HTTPAdapter(max_retries=retry_strategy))
 
+    download_path = None
     try:
         with session.get(url, stream=True) as s:
             download_path = _get_download_path(s.url, s.headers.get('content-disposition'), directory)
@@ -73,14 +74,12 @@ def download_file(
                     if chunk:
                         f.write(chunk)
                         bytes_written += len(chunk)
-            if bytes_written == 0:
-                msg = f'Downloaded 0 bytes from {url}'
-                logging.error(msg)
-                return ''
             logging.info(f'Download successful: {url}')
     except requests.exceptions.RequestException as e:
-        logging.exception('Download failed: {url}, {e}')
-        return ''
+        logging.exception(f'Download failed: {url}')
+        if download_path is not None:
+            download_path.unlink(missing_ok=True) # delete any partial downloads
+        raise
     finally:
         session.close()
 

--- a/src/multirtc/fetch.py
+++ b/src/multirtc/fetch.py
@@ -68,12 +68,10 @@ def download_file(
         with session.get(url, stream=True) as s:
             download_path = _get_download_path(s.url, s.headers.get('content-disposition'), directory)
             s.raise_for_status()
-            bytes_written = 0
             with open(download_path, 'wb') as f:
                 for chunk in s.iter_content(chunk_size=chunk_size):
                     if chunk:
                         f.write(chunk)
-                        bytes_written += len(chunk)
             logging.info(f'Download successful: {url}')
     except requests.exceptions.RequestException as e:
         logging.exception(f'Download failed: {url}')

--- a/src/multirtc/fetch.py
+++ b/src/multirtc/fetch.py
@@ -63,13 +63,25 @@ def download_file(
     session.mount('https://', HTTPAdapter(max_retries=retry_strategy))
     session.mount('http://', HTTPAdapter(max_retries=retry_strategy))
 
-    with session.get(url, stream=True) as s:
-        download_path = _get_download_path(s.url, s.headers.get('content-disposition'), directory)
-        s.raise_for_status()
-        with open(download_path, 'wb') as f:
-            for chunk in s.iter_content(chunk_size=chunk_size):
-                if chunk:
-                    f.write(chunk)
-    session.close()
+    try:
+        with session.get(url, stream=True) as s:
+            download_path = _get_download_path(s.url, s.headers.get('content-disposition'), directory)
+            s.raise_for_status()
+            bytes_written = 0
+            with open(download_path, 'wb') as f:
+                for chunk in s.iter_content(chunk_size=chunk_size):
+                    if chunk:
+                        f.write(chunk)
+                        bytes_written += len(chunk)
+            if bytes_written == 0:
+                msg = f'Downloaded 0 bytes from {url}'
+                logging.error(msg)
+                return ''
+            logging.info(f'Download successful: {url}')
+    except requests.exceptions.RequestException as e:
+        logging.exception('Download failed: {url}, {e}')
+        return ''
+    finally:
+        session.close()
 
     return str(download_path)

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -4,7 +4,7 @@ from multirtc import dem
 
 
 def test_get_granule_url():
-    test_url = 'https://nisar.asf.earthdatacloud.nasa.gov/STATIC/DEM/v1.1/EPSG4326/S10_W020/DEM_S01_00_W001_00.tif'
+    test_url = 'https://nisar.asf.earthdatacloud.nasa.gov/NISAR/DEM/v1.2/EPSG4326/S10/S10_W020/DEMS01_00_W001_00_C01.tif'
     url = dem.get_dem_granule_url(-1, -1)
     assert url == test_url
 


### PR DESCRIPTION
Version 1.1 of the NISAR DEM was pulled and replaced with v1.2, which has updated endpoints.

This PR:
- Updates the NISAR DEM endpoints in `dem.py`.
- Adds some descriptive error handling to `fetch.download_file()` to enable easier debugging the next time expected data vanishes.